### PR TITLE
Fixed install.sh for ubuntu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,8 +32,17 @@ create_user() {
 
 # dependencies: se for deb pkg, tirar
 apt-get update
-apt-get install git git-annex nginx supervisor python-pip rabbitmq-server libjpeg-dev libtiff5-dev libjpeg62-turbo-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk python-dev python-setuptools gettext
+COMMON_PKG="git git-annex nginx supervisor python-pip rabbitmq-server libjpeg-dev libtiff5-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk python-dev python-setuptools gettext"
+DEBIAN_PKG="libjpeg62-turbo-dev"
+UBUNTU_PKG="libjpeg-turbo8-dev"
 
+if [ -n "$(grep -i ubuntu /etc/os-release )" ]; then
+  PACKAGES="$COMMON_PKG $UBUNTU_PKG"
+else
+  PACKAGES="$COMMON_PKG $DEBIAN_PKG"
+fi
+
+apt-get install -y $PACKAGES || echo "Error!" && exit 1
 
 ### cria diretorio basico
 mkdir -p $DEFAULT_REPOSITORY_DIR
@@ -297,8 +306,8 @@ cp $INSTALL_DIR/baobaxia/bin/gunicorn_start.sh.example $INSTALL_DIR/bin/gunicorn
 sed -i "s:_domain_:${BBX_DIR_NAME}:g" $INSTALL_DIR/bin/gunicorn_start.sh
 touch $INSTALL_DIR/log/gunicorn_supervisor.log
 chmod +x $INSTALL_DIR/bin/gunicorn_start.sh
-chmod 775 $INSTALL_DIR/log/gunicorn_supervisor.log 
-chown $USER_BBX:$USER_BBX $INSTALL_DIR/log/gunicorn_supervisor.log 
+chmod 775 $INSTALL_DIR/log/gunicorn_supervisor.log
+chown $USER_BBX:$USER_BBX $INSTALL_DIR/log/gunicorn_supervisor.log
 
 
 # 7) recriar mucuas da rede no django-bbx (mucuaLocal)
@@ -386,4 +395,3 @@ echo "       /                                                                  
 echo "      BAOBÁXIA                                 Software LIVRE! GPLv3                 "
 
 echo ""
-

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ else
   PACKAGES="$COMMON_PKG $DEBIAN_PKG"
 fi
 
-apt-get install -y $PACKAGES || echo "Error!" && exit 1
+apt-get install -y $PACKAGES || exit 1
 
 ### cria diretorio basico
 mkdir -p $DEFAULT_REPOSITORY_DIR

--- a/install.sh
+++ b/install.sh
@@ -158,7 +158,7 @@ case "$PROTOCOL" in
 	cd $DEFAULT_REPOSITORY_DIR
 	git clone $REPO_NAME
 	;;
-    local|LOCAL|*) PROTOCOL='local'
+  local|LOCAL|*) PROTOCOL='local'
 	read -p "Defina a pasta do repositório para espelhar (padrão: /root/baobaxia/mocambos):" MIRROR_REPOSITORY_FOLDER
 	case $MIRROR_REPOSITORY_FOLDER in
 	    '') MIRROR_REPOSITORY_FOLDER="/root/baobaxia/mocambos" ;;
@@ -179,7 +179,11 @@ echo ""
 echo "Definindo usuário git para usuário do baobáxia ($USER_BBX) ..."
 echo "Criando novo repositório na mucua $MUCUA ..."
 su - $USER_BBX -c "
-cd $DEFAULT_REPOSITORY_DIR/$DEFAULT_REPOSITORY_NAME;
+if [ -d $DEFAULT_REPOSITORY_DIR/$DEFAULT_REPOSITORY_NAME ]; then
+  cd $DEFAULT_REPOSITORY_DIR/$DEFAULT_REPOSITORY_NAME;
+else
+  mkdir $DEFAULT_REPOSITORY_DIR/$DEFAULT_REPOSITORY_NAME;
+fi
 git config --global user.name 'Exu do BBX';
 git config --global user.email 'exu@mocambos.org';
 git init . ;

--- a/install.sh
+++ b/install.sh
@@ -353,7 +353,7 @@ chmod +x $INSTALL_DIR/bin/update-templates.sh
 echo ""
 echo "Ativando o Baobáxia ..."
 supervisorctl restart bbx
-supervisorctl restart celeryd
+supervisorctl restart celery
 
 
 echo ""


### PR DESCRIPTION
Hi, 

This branch fix install.sh script to be able to install baobaxia in ubuntu distro.
There are little changes:
- check distro and select right packages to install based on os
- on error apt-get install fail with exit 1
- fix start celery service
- create repo dir if not exists