### PR TITLE
FIX: fixes install.sh to install git-annex last version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,10 +31,15 @@ create_user() {
 # PRE: pkgs:
 
 # dependencies: se for deb pkg, tirar
-apt-get update
-COMMON_PKG="git git-annex nginx supervisor python-pip rabbitmq-server libjpeg-dev libtiff5-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk python-dev python-setuptools gettext"
+COMMON_PKG="git git-annex-standalone nginx supervisor python-pip rabbitmq-server libjpeg-dev libtiff5-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk python-dev python-setuptools gettext"
 DEBIAN_PKG="libjpeg62-turbo-dev"
 UBUNTU_PKG="libjpeg-turbo8-dev"
+
+if [ ! -f /usr/bin/lsb_release ]; then
+  apt-get update
+  apt-get install -y lsb-release
+fi
+DISTRO_VERSION="$(lsb_release -c -s)"
 
 if [ -n "$(grep -i ubuntu /etc/os-release )" ]; then
   PACKAGES="$COMMON_PKG $UBUNTU_PKG"
@@ -42,6 +47,10 @@ else
   PACKAGES="$COMMON_PKG $DEBIAN_PKG"
 fi
 
+wget -q -O- http://neuro.debian.net/lists/${DISTRO_VERSION}.gr.full > /etc/apt/sources.list.d/neurodebian.sources.list
+apt-key adv --recv-keys --keyserver hkp://pgp.mit.edu:80 0xA5D32F012649A5A9
+
+apt-get update
 apt-get install -y $PACKAGES || exit 1
 
 ### cria diretorio basico


### PR DESCRIPTION
Fixes #200 

install.sh script was changed to be able to install git-annex last version.

To upgrade previous installation just run this simple script:

```
#!/bin/bash

if [ ! -f /usr/bin/lsb_release ]; then
  apt-get update
  apt-get install -y lsb-release
fi
DISTRO_VERSION="$(lsb_release -c -s)"

wget -q -O- http://neuro.debian.net/lists/${DISTRO_VERSION}.gr.full > /etc/apt/sources.list.d/neurodebian.sources.list
apt-key adv --recv-keys --keyserver hkp://pgp.mit.edu:80 0xA5D32F012649A5A9

apt-get update
apt-get install git-annex-standalone

```